### PR TITLE
fix: filter out invalid 1970 timestamps on FLP and Game stats pages

### DIFF
--- a/src/contants.ts
+++ b/src/contants.ts
@@ -1,0 +1,1 @@
+ export const MIN_VALID_TIMESTAMP = 1735689600 

--- a/src/pages/FLPYield/FLPYield.tsx
+++ b/src/pages/FLPYield/FLPYield.tsx
@@ -5,6 +5,7 @@ import { AUTONOMOUS_FINANCE } from 'ao-js-sdk/dist/src/process-ids/autonomous-fi
 import { fetchFLPYieldHistory } from './flpYieldService'
 import { transformYieldData, groupDataByProcess, calculateStats, formatAO, type YieldData } from './flpYieldUtils'
 import { colors, plotConfig, createPlotLayout } from './flpYieldConfig'
+import { MIN_VALID_TIMESTAMP } from '../../constants'
 
 // Get the FLP mapping directly from the SDK
 const FAIR_LAUNCH_PROCESSES = AUTONOMOUS_FINANCE.FAIR_LAUNCH_PROCESSES
@@ -39,7 +40,7 @@ function FLPYield() {
     // Ensure we have a valid color index by using modulo
     const colorIndex = index % colors.length
     const processData = (dataByProcess[processId] || [])
-      .filter(d => d.amount > 0 && d.timestamp >= 1735689600) // Only show positive yields
+      .filter(d => d.amount > 0 && d.timestamp >= MIN_VALID_TIMESTAMP) // Only show positive yields
       .sort((a, b) => a.timestamp - b.timestamp)
     
     // Create base plot item

--- a/src/utils/data/flpData.ts
+++ b/src/utils/data/flpData.ts
@@ -2,6 +2,7 @@ import { PiDataService } from 'ao-js-sdk/dist/src/services/autonomous-finance/pi
 import type { FLPYieldHistoryEntry } from 'ao-js-sdk/dist/src/services/autonomous-finance/pi-data-service/abstract/responses'
 import { lastValueFrom } from 'rxjs'
 import { AUTONOMOUS_FINANCE } from 'ao-js-sdk/dist/src/process-ids/autonomous-finance'
+import { MIN_VALID_TIMESTAMP } from '../../constants'
 import _ from 'lodash'
 
 // Export the FLP mapping directly from the SDK
@@ -77,7 +78,7 @@ export function transformYieldData(entries: FLPYieldHistoryEntry[]): YieldData[]
 export function transformGameYieldData(entries: FLPYieldHistoryEntry[]): YieldData[] {
   return _(entries)
     .flatMap(entry => {
-      if (!entry.timestamp || entry.timestamp < 1735689600) return []
+      if (!entry.timestamp || entry.timestamp < MIN_VALID_TIMESTAMP) return []
       return _(entry.projectYields || {})
         .entries()
         .filter(([processId, yield_]) => {


### PR DESCRIPTION
This PR filters out any timestamp before 2025-01-01 to prevent skewed graph caused by 1970 data point.